### PR TITLE
Adding required Operator fee to SWaP TX

### DIFF
--- a/config/env/common.js
+++ b/config/env/common.js
@@ -191,5 +191,9 @@ export default {
   disableNewAccounts: process.env.DISABLE_NEW_ACCOUNTS ? true : false,
 
   // Admin password
-  adminPassword: process.env.ADMIN_PASSWORD
+  adminPassword: process.env.ADMIN_PASSWORD,
+
+  // The Operator of BCH DEX can elect to receive a percentage of each sale.
+  operatorAddress: process.env.OPERATOR_ADDRESS ? process.env.OPERATOR_ADDRESS : 'bitcoincash:qqsrke9lh257tqen99dkyy2emh4uty0vky9y0z0lsr',
+  operatorPercentage: process.env.OPERATOR_PERCENTAGE ? parseFloat(process.env.OPERATOR_PERCENTAGE) : 2.0
 }

--- a/src/adapters/localdb/models/offer.js
+++ b/src/adapters/localdb/models/offer.js
@@ -35,8 +35,11 @@ const Offer = new mongoose.Schema({
   lokadId: { type: String },
   messageType: { type: Number },
   messageClass: { type: Number },
-  nostrEventId: { type: String } // Nostr Event Id.
+  nostrEventId: { type: String }, // Nostr Event Id.
 
+  // Operator fee and address
+  operatorAddress: { type: String },
+  operatorPercentage: { type: Number }
 })
 
 export default mongoose.model('offer', Offer)

--- a/src/adapters/localdb/models/order.js
+++ b/src/adapters/localdb/models/order.js
@@ -43,7 +43,11 @@ const Order = new mongoose.Schema({
   // Additional properties found in createOrder
   dataType: { type: String, required: true },
 
-  userId: { type: String, required: true }
+  userId: { type: String, required: true },
+
+  // Operator fee and address
+  operatorAddress: { type: String },
+  operatorPercentage: { type: Number }
 })
 
 export default mongoose.model('order', Order)

--- a/src/entities/offer.js
+++ b/src/entities/offer.js
@@ -33,7 +33,9 @@ class OfferEntity {
       makerAddr,
       ticker,
       tokenType,
-      nostrEventId
+      nostrEventId,
+      operatorAddress,
+      operatorPercentage
     } = offerData.data
 
     // Input Validation
@@ -78,6 +80,14 @@ class OfferEntity {
     }
     if (!nostrEventId || typeof nostrEventId !== 'string') {
       throw new Error("Property 'nostrEventId' must be a string.")
+    }
+
+    // Add the operator address and percentage to the offer.
+    if (!operatorAddress || typeof operatorAddress !== 'string') {
+      throw new Error("Property 'operatorAddress' must be a string.")
+    }
+    if (!operatorPercentage || typeof operatorPercentage !== 'number') {
+      throw new Error("Property 'operatorPercentage' must be a number.")
     }
 
     // Convert the timestamp to a number.

--- a/src/entities/offer.js
+++ b/src/entities/offer.js
@@ -1,6 +1,6 @@
 /*
   Offer Entity
-  An ffer is created when a new Signal is detected via the P2WDB webhook.
+  An offer is created when a new Signal is detected via the P2WDB webhook.
   It's destroyed when the UTXO described in the Signal has been detected as spent.
 */
 

--- a/src/use-cases/offer/index.js
+++ b/src/use-cases/offer/index.js
@@ -111,7 +111,10 @@ class OfferUseCases {
       const utxoStatus = await this.retryQueue.addToQueue(this.adapters.wallet.bchWallet.utxoIsValid, utxo)
       // console.log('utxoStatus: ', utxoStatus)
       // if (utxoStatus === null) return false
-      if (!utxoStatus) return false
+      if (!utxoStatus) {
+        console.log(`UTXO txid: ${offerObj.data.utxoTxid}, vout: ${offerObj.data.utxoVout} has been spent. Skipping.`)
+        return false
+      }
 
       // A new offer gets a status of 'posted'
       offerObj.data.offerStatus = 'posted'

--- a/src/use-cases/offer/index.js
+++ b/src/use-cases/offer/index.js
@@ -591,16 +591,6 @@ class OfferUseCases {
       const txObj = await this.adapters.wallet.deseralizeTx(txHex)
       console.log(`txObj: ${JSON.stringify(txObj, null, 2)}`)
 
-      // Ensure the Counter Offer has an output for the Operator of bch-dex.
-      if (!txObj.vout[3]) {
-        console.log('The Counter Offer does not have an output for the Operator.')
-
-        // Add order to list of seen orders, so that we don't spent time trying to validate it again.
-        this.seenOffers.push(eventId)
-
-        return 'N/A'
-      }
-
       // Ensure the 3rd output (vout=2) contains the required amount of BCH.
       const satsToReceive = Math.ceil(orderData.numTokens * parseInt(orderData.rateInBaseUnit))
       console.log('Ceil', satsToReceive)
@@ -611,6 +601,16 @@ class OfferUseCases {
       const hasRequiredAmount = satsOut === satsToReceive
       if (!hasRequiredAmount) {
         throw new Error(`The Counter Offer has an output of ${satsOut}, which does not match the required ${satsToReceive} in the Offer.`)
+      }
+
+      // Ensure the Counter Offer has an output for the Operator of bch-dex.
+      if (!txObj.vout[3]) {
+        console.log('The Counter Offer does not have an output for the Operator.')
+
+        // Add order to list of seen orders, so that we don't spent time trying to validate it again.
+        this.seenOffers.push(eventId)
+
+        return 'N/A'
       }
 
       // Ensure the 3rd output (vout=2) is going to the maker address specified

--- a/test/unit/entities/offer.entity.unit.js
+++ b/test/unit/entities/offer.entity.unit.js
@@ -286,7 +286,9 @@ describe('#Offer-Entity', () => {
           makerAddr: 'bitcoincash:qzl0d3gcqeypv4cy7gh8rgdszxa9vvm2acv7fqtd00',
           ticker: 'TROUT',
           tokenType: 1,
-          nostrEventId: 'test'
+          nostrEventId: 'test',
+          operatorAddress: 'bitcoincash:qzl0d3gcqeypv4cy7gh8rgdszxa9vvm2acv7fqtd00',
+          operatorPercentage: 10
         },
         timestamp: '2021-09-20T17:54:26.395Z',
         localTimeStamp: '9/20/2021, 10:54:26 AM',

--- a/test/unit/mocks/use-cases/offer-mock-data.js
+++ b/test/unit/mocks/use-cases/offer-mock-data.js
@@ -142,13 +142,46 @@ const offerMockData = {
     utxoVout: 0,
     makerAddr: 'address',
     tokenType: 1,
-    nostrEventId: 'test'
+    nostrEventId: 'test',
+    operatorAddress: 'bitcoincash:qzy97glp47ut7tstm5g0tlrmkhk742795gkmyc7478',
+    operatorPercentage: 10
   }
+}
+
+const deserealizeTxMockNoOperatorOut = {
+  //...
+  vout: [
+    {
+      value: 0,
+      scriptPubKey: {
+        addresses: ['bitcoincash:qzy97glp47ut7tstm5g0tlrmkhk742795gkmyc7478']
+      }
+    },
+    {
+      value: 0,
+      scriptPubKey: {
+        addresses: ['bitcoincash:qzy97glp47ut7tstm5g0tlrmkhk742795gkmyc7478']
+      }
+    },
+    {
+      value: 0,
+      scriptPubKey: {
+        addresses: ['bitcoincash:qzy97glp47ut7tstm5g0tlrmkhk742795gkmyc7478']
+      }
+    },
+    //...
+  ]
 }
 
 const deserealizeTxMock = {
   //...
   vout: [
+    {
+      value: 0,
+      scriptPubKey: {
+        addresses: ['bitcoincash:qzy97glp47ut7tstm5g0tlrmkhk742795gkmyc7478']
+      }
+    },
     {
       value: 0,
       scriptPubKey: {
@@ -179,5 +212,6 @@ export default {
   fungibleOffer01,
   fungibleTokenData01,
   offerMockData,
+  deserealizeTxMockNoOperatorOut,
   deserealizeTxMock
 };

--- a/test/unit/use-cases/offer.use-case.unit.js
+++ b/test/unit/use-cases/offer.use-case.unit.js
@@ -746,6 +746,24 @@ describe('#offer-use-case', () => {
       }
     })
 
+    it('should skip transactions that do not have an output for the operator', async () => {
+      // Mock data
+      const mock = Object.assign({}, mockData.offerMockData.data)
+      mock.makerAddr = 'bitcoincash:qzy97glp47ut7tstm5g0tlrmkhk742795gkmyc7477' // Unknow Adress
+      mock.rateInBaseUnit = 0
+      mock.numTokens = 0
+
+      // Mock dependencies
+      sandbox.stub(uut.orderUseCase, 'findOrderByEvent').resolves(mock)
+      sandbox.stub(uut.orderUseCase, 'findOrderByUtxo').resolves(mock)
+      sandbox.stub(uut.adapters.wallet.bchWallet.bchjs.BitcoinCash, 'toSatoshi').returns(0)
+
+      sandbox.stub(uut.adapters.wallet, 'deseralizeTx').resolves(mockData.deserealizeTxMockNoOperatorOut)
+
+      const result = await uut.acceptCounterOffer({ data: { /** .... */ } })
+      assert.equal(result, 'N/A')
+    })
+
     it('should handle error for wrong transaction output address', async () => {
       try {
         // Mock data

--- a/test/unit/use-cases/order.use-case.unit.js
+++ b/test/unit/use-cases/order.use-case.unit.js
@@ -185,6 +185,7 @@ describe('#order-use-case', () => {
       assert.property(result, 'eventId')
       assert.property(result, 'noteId')
     })
+
     it('should create an order with consumer-api', async () => {
       uut.config.useFullStackCash = false
       const entryObj = {
@@ -214,6 +215,7 @@ describe('#order-use-case', () => {
       assert.property(result, 'eventId')
       assert.property(result, 'noteId')
     })
+    
     it('should throw error if user is not found', async () => {
       try {
         const entryObj = {

--- a/test/unit/use-cases/order.use-case.unit.js
+++ b/test/unit/use-cases/order.use-case.unit.js
@@ -215,7 +215,7 @@ describe('#order-use-case', () => {
       assert.property(result, 'eventId')
       assert.property(result, 'noteId')
     })
-    
+
     it('should throw error if user is not found', async () => {
       try {
         const entryObj = {


### PR DESCRIPTION
This feature requires that SWaP transaction contain an extra output to pay the operator of bch-dex which hosts the Order. The goal of this is to provide incentive for more people to operate bch-dex nodes.